### PR TITLE
StateSequences Improvement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ plugins {
 }
 
 // Core versioning
-version = "0.5.1b23"
+version = "0.5.1b24"
 
 allprojects {
     apply from: "${rootDir}/gradle/tasks.gradle"

--- a/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/state/StateSequencesTest.java
+++ b/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/state/StateSequencesTest.java
@@ -60,7 +60,8 @@ public class StateSequencesTest extends TestingBase {
 
     private static class ExState extends StateBase {
 
-        private boolean start, end;
+        private boolean start;
+        private boolean end;
 
         @Override
         protected void onStart() {
@@ -69,7 +70,7 @@ public class StateSequencesTest extends TestingBase {
 
         @Override
         protected void onUpdate() {
-
+            // nothing
         }
 
         @Override

--- a/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/state/StateSequencesTest.java
+++ b/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/state/StateSequencesTest.java
@@ -1,0 +1,81 @@
+package io.fairytest.state;
+
+import io.fairyproject.state.StateBase;
+import io.fairyproject.state.StateSequences;
+import io.fairyproject.tests.TestingBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StateSequencesTest extends TestingBase {
+
+    @Test
+    public void sequenceSkipTo() {
+        ExState a = new ExState();
+        ExState b = new ExState();
+        ExState c = new ExState();
+        ExState d = new ExState();
+
+        StateSequences states = new StateSequences(a, b, c, d);
+        states.start();
+
+        states.skip(3);
+        states.update();
+        Assert.assertTrue(a.start);
+        Assert.assertTrue(a.end);
+
+        Assert.assertTrue(b.start);
+        Assert.assertTrue(b.end);
+
+        Assert.assertTrue(c.start);
+        Assert.assertTrue(c.end);
+
+        Assert.assertTrue(d.start);
+        Assert.assertFalse(d.end);
+    }
+
+    @Test
+    public void sequenceSkipToWithoutNotifyOthers() {
+        ExState a = new ExState();
+        ExState b = new ExState();
+        ExState c = new ExState();
+        ExState d = new ExState();
+
+        StateSequences states = new StateSequences(a, b, c, d);
+        states.start();
+
+        states.skip(3, true);
+        states.update();
+        Assert.assertTrue(a.start);
+        Assert.assertTrue(a.end);
+
+        Assert.assertFalse(b.start);
+        Assert.assertFalse(b.end);
+
+        Assert.assertFalse(c.start);
+        Assert.assertFalse(c.end);
+
+        Assert.assertTrue(d.start);
+        Assert.assertFalse(d.end);
+    }
+
+    private static class ExState extends StateBase {
+
+        private boolean start, end;
+
+        @Override
+        protected void onStart() {
+            this.start = true;
+        }
+
+        @Override
+        protected void onUpdate() {
+
+        }
+
+        @Override
+        protected void onEnded() {
+            this.end = true;
+        }
+    }
+
+}


### PR DESCRIPTION
Added skipTo(index) and skipTo(index, withoutNotifyOthers)

skipTo(index, withoutNotifyOthers) - will only call end for current state and call start for target state

## TODO:
- [x] Testing
- [x] Code style fixes