### PR TITLE
Improved Serializers

### DIFF
--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/ObjectSerializer.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/ObjectSerializer.java
@@ -24,12 +24,38 @@
 
 package io.fairyproject;
 
+/**
+ * The serializer that serializes type from I to O.
+ * You can register through annotating {@link io.fairyproject.container.Component} or {@link io.fairyproject.container.SerializerFactory#registerSerializer(ObjectSerializer)}
+ * @param <I> the input type
+ * @param <O> the output type
+ */
 public interface ObjectSerializer<I, O> {
 
+    /**
+     * Serialize an instance from input type to output type.
+     * @param input the input instance
+     * @return the output instance
+     */
     O serialize(I input);
+
+    /**
+     * Deserialize an instance from output type to input type.
+     * @param output the output instance
+     * @return the input instance
+     */
     I deserialize(O output);
 
+    /**
+     * The input type
+     * @return type
+     */
     Class<I> inputClass();
+
+    /**
+     * The output type
+     * @return type
+     */
     Class<O> outputClass();
 
 }

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/SerializerFactory.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/SerializerFactory.java
@@ -103,6 +103,15 @@ public class SerializerFactory {
     }
 
     /**
+     * Unregister an existing serializer.
+     * @param type The serializer key type
+     * @return true if unregister success
+     */
+    public boolean unregisterSerializer(@NotNull Class<?> type) {
+        return this.serializers.remove(type) != null;
+    }
+
+    /**
      * Search for the serializer instance by key type.
      * @param type the type of the serializer you are looking for
      * @return the serializer instance, null if not found

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/SerializerFactory.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/SerializerFactory.java
@@ -118,7 +118,7 @@ public class SerializerFactory {
      */
     @Nullable
     public ObjectSerializer<?, ?> findSerializer(@NotNull Class<?> type) {
-        final SerializerData serializerData = this.serializers.getOrDefault(type, null);
+        final SerializerData serializerData = this.serializers.get(type);
         return serializerData != null ? serializerData.getSerializer() : null;
     }
 

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/SerializerJacksonConfigure.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/SerializerJacksonConfigure.java
@@ -26,20 +26,23 @@ package io.fairyproject.container;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import io.fairyproject.jackson.JacksonConfigure;
-import lombok.AllArgsConstructor;
 import io.fairyproject.ObjectSerializer;
+import io.fairyproject.jackson.JacksonConfigure;
+import io.fairyproject.jackson.JacksonObjectDeserializer;
+import io.fairyproject.jackson.JacksonObjectSerializer;
+import lombok.RequiredArgsConstructor;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class SerializerJacksonConfigure implements JacksonConfigure {
 
     private final ObjectSerializer<?, ?> serializer;
 
+    @SuppressWarnings("unchecked")
     @Override
     public void configure(ObjectMapper objectMapper) {
         final SimpleModule module = new SimpleModule();
-        module.addSerializer(new SerializerFactory.JacksonSerailizer(serializer));
-        module.addDeserializer(serializer.inputClass(), new SerializerFactory.JacksonDeserailizer(serializer));
+        module.addSerializer(new JacksonObjectSerializer(serializer));
+        module.addDeserializer(serializer.inputClass(), new JacksonObjectDeserializer(serializer));
 
         objectMapper.registerModule(module);
     }

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/jackson/JacksonObjectDeserializer.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/jackson/JacksonObjectDeserializer.java
@@ -1,0 +1,28 @@
+package io.fairyproject.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import io.fairyproject.ObjectSerializer;
+
+import java.io.IOException;
+
+@SuppressWarnings("rawtypes")
+public class JacksonObjectDeserializer extends StdDeserializer {
+
+    private final ObjectSerializer serializer;
+
+    @SuppressWarnings("unchecked")
+    public JacksonObjectDeserializer(ObjectSerializer serializer) {
+        super(serializer.inputClass());
+        this.serializer = serializer;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException, JsonProcessingException {
+        return serializer.deserialize(jsonParser.readValueAs(serializer.outputClass()));
+    }
+
+}

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/jackson/JacksonObjectSerializer.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/jackson/JacksonObjectSerializer.java
@@ -1,0 +1,26 @@
+package io.fairyproject.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.fairyproject.ObjectSerializer;
+
+import java.io.IOException;
+
+@SuppressWarnings("rawtypes")
+public class JacksonObjectSerializer extends StdSerializer {
+
+    private final ObjectSerializer serializer;
+
+    @SuppressWarnings("unchecked")
+    public JacksonObjectSerializer(ObjectSerializer serializer) {
+        super(serializer.inputClass());
+        this.serializer = serializer;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void serialize(Object value, JsonGenerator jsonGenerator, SerializerProvider provider) throws IOException {
+        jsonGenerator.writeObject(serializer.serialize(value));
+    }
+}

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/serializer/AvoidDuplicate.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/serializer/AvoidDuplicate.java
@@ -1,0 +1,19 @@
+package io.fairyproject.serializer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mark a {@link io.fairyproject.ObjectSerializer} class to avoid key type duplication.
+ *
+ * if duplication happens, it will always prioritize the first one that has been registered,
+ * This annotation will strictly lock the serializer to 1 only each key.
+ * Without this annotation, no error will be thrown but instead a warning will show up in console.
+ * With this annotation, error will be thrown and potentially make the plugin not working.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AvoidDuplicate {
+}

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/serializer/SerializerData.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/serializer/SerializerData.java
@@ -1,0 +1,14 @@
+package io.fairyproject.serializer;
+
+import io.fairyproject.ObjectSerializer;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Data
+public class SerializerData {
+
+    private final ObjectSerializer<?, ?> serializer;
+    private final boolean avoidDuplication;
+
+}

--- a/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/ObjectSerializerAvoidDuplicationMock.java
+++ b/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/ObjectSerializerAvoidDuplicationMock.java
@@ -1,0 +1,37 @@
+package io.fairytest.serializer;
+
+import io.fairyproject.ObjectSerializer;
+import io.fairyproject.serializer.AvoidDuplicate;
+
+@AvoidDuplicate
+public class ObjectSerializerAvoidDuplicationMock<I, O> implements ObjectSerializer<I, O> {
+
+    private final Class<I> i;
+    private final Class<O> o;
+
+    public ObjectSerializerAvoidDuplicationMock(Class<I> i, Class<O> o) {
+        this.i = i;
+        this.o = o;
+    }
+
+    @Override
+    public O serialize(I input) {
+        return null;
+    }
+
+    @Override
+    public I deserialize(O output) {
+        return null;
+    }
+
+    @Override
+    public Class<I> inputClass() {
+        return this.i;
+    }
+
+    @Override
+    public Class<O> outputClass() {
+        return this.o;
+    }
+
+}

--- a/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/ObjectSerializerMock.java
+++ b/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/ObjectSerializerMock.java
@@ -1,0 +1,35 @@
+package io.fairytest.serializer;
+
+import io.fairyproject.ObjectSerializer;
+
+public class ObjectSerializerMock<I, O> implements ObjectSerializer<I, O> {
+
+    private final Class<I> i;
+    private final Class<O> o;
+
+    public ObjectSerializerMock(Class<I> i, Class<O> o) {
+        this.i = i;
+        this.o = o;
+    }
+
+    @Override
+    public O serialize(I input) {
+        return null;
+    }
+
+    @Override
+    public I deserialize(O output) {
+        return null;
+    }
+
+    @Override
+    public Class<I> inputClass() {
+        return this.i;
+    }
+
+    @Override
+    public Class<O> outputClass() {
+        return this.o;
+    }
+
+}

--- a/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/SerializerFactoryTest.java
+++ b/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/SerializerFactoryTest.java
@@ -1,0 +1,87 @@
+package io.fairytest.serializer;
+
+import io.fairyproject.ObjectSerializer;
+import io.fairyproject.container.Containers;
+import io.fairyproject.container.SerializerFactory;
+import io.fairyproject.tests.TestingBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SerializerFactoryTest extends TestingBase {
+
+    @AfterEach
+    public void afterEach() {
+        final SerializerFactory serializerFactory = Containers.get(SerializerFactory.class);
+
+        serializerFactory.unregisterSerializer(TestKey.class);
+    }
+
+    @Test
+    public void findSerializer() {
+        final SerializerFactory serializerFactory = Containers.get(SerializerFactory.class);
+
+        ObjectSerializer<TestKey, TestKey> a = new ObjectSerializerAvoidDuplicationMock<>(TestKey.class, TestKey.class);
+        serializerFactory.registerSerializer(a);
+        Assertions.assertEquals(a, serializerFactory.findSerializer(TestKey.class));
+    }
+
+    @Test
+    public void findSerializerNoRegister() {
+        final SerializerFactory serializerFactory = Containers.get(SerializerFactory.class);
+
+        Assertions.assertNull(serializerFactory.findSerializer(TestKey.class));
+    }
+
+    @Test
+    public void serializerUnregisterNull() {
+        final SerializerFactory serializerFactory = Containers.get(SerializerFactory.class);
+
+        ObjectSerializer<TestKey, TestKey> a = new ObjectSerializerAvoidDuplicationMock<>(TestKey.class, TestKey.class);
+        serializerFactory.registerSerializer(a);
+        serializerFactory.unregisterSerializer(a);
+
+        Assertions.assertNull(serializerFactory.findSerializer(TestKey.class));
+    }
+
+    @Test
+    public void serializerKeyOrder() {
+        final SerializerFactory serializerFactory = Containers.get(SerializerFactory.class);
+
+        ObjectSerializer<TestKey, TestKey> a = new ObjectSerializerMock<>(TestKey.class, TestKey.class);
+        ObjectSerializer<TestKey, TestKey> b = new ObjectSerializerMock<>(TestKey.class, TestKey.class);
+
+        serializerFactory.registerSerializer(a);
+        serializerFactory.registerSerializer(b);
+
+        Assertions.assertEquals(a, serializerFactory.findSerializer(TestKey.class));
+    }
+
+    @Test
+    public void serializerAvoidDuplication() {
+        final SerializerFactory serializerFactory = Containers.get(SerializerFactory.class);
+
+        ObjectSerializer<TestKey, TestKey> a = new ObjectSerializerAvoidDuplicationMock<>(TestKey.class, TestKey.class);
+        ObjectSerializer<TestKey, TestKey> b = new ObjectSerializerAvoidDuplicationMock<>(TestKey.class, TestKey.class);
+
+        serializerFactory.registerSerializer(a);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            serializerFactory.registerSerializer(b);
+        });
+    }
+
+    @Test
+    public void serializerUnregisterDuplication() {
+        final SerializerFactory serializerFactory = Containers.get(SerializerFactory.class);
+
+        ObjectSerializer<TestKey, TestKey> a = new ObjectSerializerAvoidDuplicationMock<>(TestKey.class, TestKey.class);
+        ObjectSerializer<TestKey, TestKey> b = new ObjectSerializerAvoidDuplicationMock<>(TestKey.class, TestKey.class);
+
+        serializerFactory.registerSerializer(a);
+        serializerFactory.unregisterSerializer(a);
+        serializerFactory.registerSerializer(b);
+    }
+
+    public static class TestKey { }
+
+}

--- a/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/SerializerFactoryTest.java
+++ b/io.fairyproject.platforms/core-platform/src/test/java/io/fairytest/serializer/SerializerFactoryTest.java
@@ -78,8 +78,9 @@ public class SerializerFactoryTest extends TestingBase {
         ObjectSerializer<TestKey, TestKey> b = new ObjectSerializerAvoidDuplicationMock<>(TestKey.class, TestKey.class);
 
         serializerFactory.registerSerializer(a);
-        serializerFactory.unregisterSerializer(a);
+        Assertions.assertTrue(serializerFactory.unregisterSerializer(a));
         serializerFactory.registerSerializer(b);
+        Assertions.assertEquals(b, serializerFactory.findSerializer(TestKey.class));
     }
 
     public static class TestKey { }


### PR DESCRIPTION
Don't throw error if duplication happens unless serializer mark as `@AvoidDuplicate` 
Separate JacksonObjectSerializer and JacksonObjectDeserializer to independent class 
Cleaned up JacksonObjectSerializer, JacksonObjectDeserializer and SerializerFactory 
Documented SerializerFactory 
Documented ObjectSerializer
Fixed #40

## TODO:
- [x] Unit tests
- [x] Code style fixes