### PR TITLE
Added no arg command support

### DIFF
--- a/io.fairyproject.modules/module.command/core-command/src/main/java/io/fairyproject/command/BaseCommand.java
+++ b/io.fairyproject.modules/module.command/core-command/src/main/java/io/fairyproject/command/BaseCommand.java
@@ -51,6 +51,7 @@ public abstract class BaseCommand implements ICommand {
 
     protected final HashMultimap<String, ICommand> subCommands = HashMultimap.create();
     protected final List<ICommand> sortedCommands = new ArrayList<>();
+    protected ICommand noArgCommand;
     protected Map<String, ArgCompletionHolder> tabCompletion;
 
     @Getter
@@ -344,15 +345,20 @@ public abstract class BaseCommand implements ICommand {
     }
 
     private PossibleSearches findPossibleSubCommands(CommandContext commandContext, String[] args) {
-        for (int i = args.length; i >= 0; i--) {
-            String subcommand = StringUtils.join(args, " ", 0, i).toLowerCase();
-            Set<ICommand> commands = subCommands.get(subcommand);
+        if (args.length == 0) {
+            if (this.noArgCommand != null) {
+                return new PossibleSearches(Collections.singleton(this.noArgCommand), args, "");
+            }
+        } else {
+            for (int i = args.length; i >= 0; i--) {
+                String subcommand = StringUtils.join(args, " ", 0, i).toLowerCase();
+                Set<ICommand> commands = subCommands.get(subcommand);
 
-            if (!commands.isEmpty()) {
-                return new PossibleSearches(commands, CoreCommandUtil.arrayFromRange(args, i, args.length - 1), subcommand);
+                if (!commands.isEmpty()) {
+                    return new PossibleSearches(commands, CoreCommandUtil.arrayFromRange(args, i, args.length - 1), subcommand);
+                }
             }
         }
-
         return null;
     }
 

--- a/io.fairyproject.modules/module.command/core-command/src/main/java/io/fairyproject/command/annotation/Command.java
+++ b/io.fairyproject.modules/module.command/core-command/src/main/java/io/fairyproject/command/annotation/Command.java
@@ -29,12 +29,26 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * The annotation to apply command names and permission to a command
+ * This should be used on top of a main command and a method for sub command
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 public @interface Command {
 
+    /**
+     * The name of the command
+     *
+     * @return an array of command names, # for no arg sub command
+     */
     String[] value();
 
+    /**
+     * The permission of the command
+     *
+     * @return the permission, empty if no permission required
+     */
     String permissionNode() default "";
 
 }


### PR DESCRIPTION
```java
    @Command("test")
    public class TestCommand extends BaseCommand {
        @Command("#")
        public void main(CommandContext commandContext) {

        }
    }
```

the # stands for no args command, so if you execute `/test` you are getting # executed

## TODO:
- [x] Code style fixes