### PR TITLE
Fix ItemBuilder#unbreakable

### DIFF
--- a/io.fairyproject.modules/platform.bukkit/bukkit-items/src/main/java/io/fairyproject/bukkit/util/items/ItemBuilder.java
+++ b/io.fairyproject.modules/platform.bukkit/bukkit-items/src/main/java/io/fairyproject/bukkit/util/items/ItemBuilder.java
@@ -106,6 +106,7 @@ public class ItemBuilder implements Listener, Cloneable {
 	public ItemBuilder unbreakable(final boolean unbreakable) {
 		final ItemMeta meta = itemStack.getItemMeta();
 		meta.setUnbreakable(unbreakable);
+		itemStack.setItemMeta(meta);
 		return this;
 	}
 


### PR DESCRIPTION
The ItemMeta of the ItemStack is not being re-set after setting it to unbreakable