### PR TITLE
Use method with generic rather than static fields

### DIFF
--- a/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/listener/events/Events.java
+++ b/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/listener/events/Events.java
@@ -53,9 +53,6 @@ public class Events {
 
     public final MetadataKey<EventSubscriptionList> SUBSCRIPTION_LIST = MetadataKey.create(Fairy.METADATA_PREFIX + "SubscriptionList", EventSubscriptionList.class);
 
-    public final Consumer<Cancellable> CANCEL = e -> e.setCancelled(true);
-    public final Predicate<Cancellable> IGNORE_CANCELLED = e -> !e.isCancelled();
-    public final Predicate<Cancellable> IGNORE_UNCANCELLED = Cancellable::isCancelled;
     public final Predicate<PlayerLoginEvent> IGNORE_DISALLOWED_LOGIN = e -> e.getResult() == PlayerLoginEvent.Result.ALLOWED;
     public final Predicate<AsyncPlayerPreLoginEvent> IGNORE_DISALLOWED_PRE_LOGIN = e -> e.getLoginResult() == AsyncPlayerPreLoginEvent.Result.ALLOWED;
 
@@ -74,6 +71,18 @@ public class Events {
             (e.getFrom().getBlockX() >> 4) != (e.getTo().getBlockX() >> 4) ||
                     (e.getFrom().getBlockZ() >> 4) != (e.getTo().getBlockZ() >> 4) ||
                     !e.getFrom().getWorld().equals(e.getTo().getWorld());
+
+    public <T extends Cancellable> Consumer<T> cancel() {
+        return event -> event.setCancelled(true);
+    }
+
+    public <T extends Cancellable> Predicate<T> ignoreCancelled() {
+        return e -> !e.isCancelled();
+    }
+
+    public <T extends Cancellable> Predicate<T> ignoreUncancelled() {
+        return Cancellable::isCancelled;
+    }
 
     public ListenerSubscription subscribe(Listener... listeners) {
         if (listeners.length == 0) {


### PR DESCRIPTION
Originally you can't use the field since java compiler cannot pass it.
By using method with generic java compiler will be able to recognize them and pass the value in.