### PR TITLE
Reflect Wrapper

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@
 #
 
 # Fairy
-fairy.version = 0.6.1b6-SNAPSHOT
+fairy.version = 0.6.1b7-SNAPSHOT
 gradle-plugin.version = 1.2.0b9
 
 mongojack.version = 4.2.0

--- a/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/impl/BukkitPluginHandler.java
+++ b/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/impl/BukkitPluginHandler.java
@@ -27,9 +27,9 @@ package io.fairyproject.bukkit.impl;
 import io.fairyproject.bukkit.FairyBukkitPlatform;
 import io.fairyproject.bukkit.util.JavaPluginUtil;
 import io.fairyproject.plugin.PluginHandler;
+import io.fairyproject.reflect.wrapper.ReflectWrapper;
 import io.fairyproject.util.AccessUtil;
 import io.fairyproject.util.exceptionally.SneakyThrowUtil;
-import io.github.toolfactory.narcissus.Narcissus;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
@@ -43,8 +43,8 @@ public class BukkitPluginHandler implements PluginHandler {
     public BukkitPluginHandler() {
         Field field;
         try {
-            final Class<?> pluginClassLoader = Narcissus.findClass("org.bukkit.plugin.java.PluginClassLoader");
-            field = Narcissus.findField(pluginClassLoader, "plugin");
+            final Class<?> pluginClassLoader = ReflectWrapper.get().findClass("org.bukkit.plugin.java.PluginClassLoader");
+            field = ReflectWrapper.get().findField(pluginClassLoader, "plugin");
             AccessUtil.setAccessible(field);
         } catch (Throwable throwable) {
             SneakyThrowUtil.sneakyThrow(throwable);

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/reflect/wrapper/DefaultReflectWrapper.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/reflect/wrapper/DefaultReflectWrapper.java
@@ -1,0 +1,48 @@
+package io.fairyproject.reflect.wrapper;
+
+import io.fairyproject.util.AccessUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class DefaultReflectWrapper implements ReflectWrapper {
+    @Override
+    public void setField(@NotNull Object instance, @NotNull Field field, @NotNull Object value) {
+        try {
+            field.set(instance, value);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Class<?> findClass(@NotNull String name) {
+        try {
+            return Class.forName(name);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Field findField(@NotNull Class<?> aClass, @NotNull String fieldName) throws NoSuchFieldException {
+        return aClass.getDeclaredField(fieldName);
+    }
+
+    @Override
+    public Method findMethod(@NotNull Class<?> aClass, @NotNull String methodName, final Class<?>... paramTypes) throws NoSuchMethodException {
+        return aClass.getDeclaredMethod(methodName, paramTypes);
+    }
+
+    @Override
+    public @Nullable Object invokeMethod(@NotNull Object instance, @NotNull Method method, Object... params) {
+        try {
+            AccessUtil.setAccessible(method);
+            return method.invoke(instance, params);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/reflect/wrapper/NarcissusReflectWrapper.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/reflect/wrapper/NarcissusReflectWrapper.java
@@ -1,0 +1,35 @@
+package io.fairyproject.reflect.wrapper;
+
+import io.github.toolfactory.narcissus.Narcissus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class NarcissusReflectWrapper implements ReflectWrapper {
+    @Override
+    public void setField(@NotNull Object instance, @NotNull Field field, @NotNull Object value) {
+         Narcissus.setField(instance, field, value);
+    }
+
+    @Override
+    public Class<?> findClass(@NotNull String name) {
+        return Narcissus.findClass(name);
+    }
+
+    @Override
+    public Field findField(@NotNull Class<?> aClass, @NotNull String fieldName) throws NoSuchFieldException {
+        return Narcissus.findField(aClass, fieldName);
+    }
+
+    @Override
+    public Method findMethod(@NotNull Class<?> aClass, @NotNull String methodName, Class<?>... paramTypes) throws NoSuchMethodException {
+        return Narcissus.findMethod(aClass, methodName, paramTypes);
+    }
+
+    @Override
+    public @Nullable Object invokeMethod(@NotNull Object instance, @NotNull Method method, Object... params) {
+        return Narcissus.invokeMethod(instance, method, params);
+    }
+}

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/reflect/wrapper/ReflectWrapper.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/reflect/wrapper/ReflectWrapper.java
@@ -1,0 +1,41 @@
+package io.fairyproject.reflect.wrapper;
+
+import io.github.toolfactory.narcissus.Narcissus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public interface ReflectWrapper {
+
+    static ReflectWrapper get() {
+        return Companion.INSTANCE;
+    }
+
+    void setField(@NotNull Object instance, @NotNull Field field, @NotNull Object value);
+
+    Class<?> findClass(@NotNull String name);
+
+    Field findField(@NotNull Class<?> aClass, @NotNull String fieldName) throws NoSuchFieldException;
+
+    @Nullable
+    Object invokeMethod(@NotNull Object instance, @NotNull Method method, Object... params);
+
+    Method findMethod(@NotNull Class<?> aClass, @NotNull String methodName, final Class<?>... paramTypes) throws NoSuchMethodException;
+
+    class Companion {
+
+        public static ReflectWrapper INSTANCE;
+
+        static {
+            if (Narcissus.libraryLoaded) {
+                INSTANCE = new NarcissusReflectWrapper();
+            } else {
+                INSTANCE = new DefaultReflectWrapper();
+            }
+        }
+
+    }
+
+}

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/util/AccessUtil.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/util/AccessUtil.java
@@ -24,7 +24,7 @@
 
 package io.fairyproject.util;
 
-import io.github.toolfactory.narcissus.Narcissus;
+import io.fairyproject.reflect.wrapper.ReflectWrapper;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -58,30 +58,19 @@ public abstract class AccessUtil {
 		} catch (Throwable e) {
 			if (e.getClass().getName().equals("java.lang.reflect.InaccessibleObjectException")) {
 				// Java 16 compatibility
-				final Method method = Narcissus.findMethod(Field.class, "setAccessible0", boolean.class);
-				Narcissus.invokeMethod(field, method, true);
+				final Method method = ReflectWrapper.get().findMethod(Field.class, "setAccessible0", boolean.class);
+				ReflectWrapper.get().invokeMethod(field, method, true);
 			}
 			if ("modifiers".equals(e.getMessage()) || (e.getCause() != null && e.getCause().getMessage() != null &&  e.getCause().getMessage().equals("modifiers"))) {
 				// https://github.com/ViaVersion/ViaVersion/blob/e07c994ddc50e00b53b728d08ab044e66c35c30f/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaInjector.java
 				// Java 12 compatibility *this is fine*
 				Field[] fields;
-				if (Narcissus.libraryLoaded) {
-					final Method getDeclaredFields0 = Narcissus.findMethod(Class.class, "getDeclaredFields0", boolean.class);
-					final Object o = Narcissus.invokeObjectMethod(Field.class, getDeclaredFields0, false);
-					fields = (Field[]) o;
-				} else {
-					Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
-					getDeclaredFields0.setAccessible(true);
-					fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
-				}
+				final Method getDeclaredFields0 = ReflectWrapper.get().findMethod(Class.class, "getDeclaredFields0", boolean.class);
+				final Object o = ReflectWrapper.get().invokeMethod(Field.class, getDeclaredFields0, false);
+				fields = (Field[]) o;
 				for (Field classField : fields) {
 					if ("modifiers".equals(classField.getName())) {
-						if (Narcissus.libraryLoaded) {
-							Narcissus.setField(field, classField, modifiers & ~Modifier.FINAL);
-						} else {
-							classField.setAccessible(true);
-							classField.set(field, modifiers & ~Modifier.FINAL);
-						}
+						ReflectWrapper.get().setField(field, classField, modifiers & ~Modifier.FINAL);
 						break;
 					}
 				}


### PR DESCRIPTION
To bypass Java 16's strong reflection detection
We were using Narcissus to bypass from native system

But it turns out that currently Narcissus cannot work properly on M1 machines
So it is better to have a wrapper so we can use java reflection if Narcissus cannot work properly
