### PR TITLE
fix: Add method for exact class binding retrieval

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@
 #
 
 # Fairy
-fairy.version = 0.7.0b5-SNAPSHOT
+fairy.version = 0.7.0b5-dev-SNAPSHOT
 gradle-plugin.version = 1.2.0b9
 
 mongojack.version = 4.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@
 #
 
 # Fairy
-fairy.version = 0.7.0b5-dev-SNAPSHOT
+fairy.version = 0.7.0b6-SNAPSHOT
 gradle-plugin.version = 1.2.0b9
 
 mongojack.version = 4.2.0

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/binder/ContainerObjectBinder.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/binder/ContainerObjectBinder.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.Nullable;
 public interface ContainerObjectBinder {
     @Nullable ContainerObj getBinding(Class<?> type);
 
+    @Nullable ContainerObj getExactBinding(Class<?> classType);
+
     boolean isBound(Class<?> type);
 
     void bind(Class<?> type, ContainerObj object);

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/binder/ContainerObjectBinderImpl.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/binder/ContainerObjectBinderImpl.java
@@ -44,6 +44,11 @@ public class ContainerObjectBinderImpl implements ContainerObjectBinder {
         return obj;
     }
 
+    @Override
+    public @Nullable ContainerObj getExactBinding(Class<?> classType) {
+        return this.bindings.get(classType);
+    }
+
     private ContainerObj findBindingAssignableByType(Class<?> type) {
         for (ContainerObj value : this.bindings.values()) {
             Class<?> valueType = value.getType();

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeClassScanner.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeClassScanner.java
@@ -141,7 +141,7 @@ public class ContainerNodeClassScanner {
     }
 
     private ContainerObj getOrLoadComponentObject(Class<?> javaClass) {
-        ContainerObj binding = this.binder.getBinding(javaClass);
+        ContainerObj binding = this.binder.getExactBinding(javaClass);
         if (binding != null)
             return binding;
 

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeConfigurationScanner.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeConfigurationScanner.java
@@ -47,6 +47,7 @@ public class ContainerNodeConfigurationScanner {
     public void load() {
         this.createConfigurationInstance();
 
+        System.out.println("Loading configuration: " + configurationClass.getName());
         for (Method method : configurationClass.getDeclaredMethods()) {
             if (method.isAnnotationPresent(InjectableComponent.class))
                 this.loadConfigurationMethod(method, override);
@@ -67,7 +68,8 @@ public class ContainerNodeConfigurationScanner {
         InstanceProvider provider = new MethodInvokeInstanceProvider(this.instance, method);
 
         Class<?> javaClass = provider.getType();
-        ContainerObj object = this.binder.getBinding(javaClass);
+        ContainerObj object = this.binder.getExactBinding(javaClass);
+
         if (object != null) {
             if (override) {
                 object.setInstanceProvider(provider);
@@ -88,6 +90,17 @@ public class ContainerNodeConfigurationScanner {
         if (annotation != null) {
             object.setScope(annotation.scope());
         }
+
+        System.out.println("Adding component: " + object.getType().getName());
+
+        /**
+         *  InterfaceA, InterfaceB <- ClassA
+         *
+         *
+         *  ClassA -> ClassA
+         *  InterfaceA -> ClassA
+         *  InterfaceB -> ClassA
+         */
 
         this.scanner.addComponentClass(object, scanner.getNode());
     }

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeConfigurationScanner.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeConfigurationScanner.java
@@ -47,7 +47,6 @@ public class ContainerNodeConfigurationScanner {
     public void load() {
         this.createConfigurationInstance();
 
-        System.out.println("Loading configuration: " + configurationClass.getName());
         for (Method method : configurationClass.getDeclaredMethods()) {
             if (method.isAnnotationPresent(InjectableComponent.class))
                 this.loadConfigurationMethod(method, override);
@@ -90,17 +89,6 @@ public class ContainerNodeConfigurationScanner {
         if (annotation != null) {
             object.setScope(annotation.scope());
         }
-
-        System.out.println("Adding component: " + object.getType().getName());
-
-        /**
-         *  InterfaceA, InterfaceB <- ClassA
-         *
-         *
-         *  ClassA -> ClassA
-         *  InterfaceA -> ClassA
-         *  InterfaceB -> ClassA
-         */
 
         this.scanner.addComponentClass(object, scanner.getNode());
     }

--- a/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeLegacyScanner.java
+++ b/io.fairyproject.platforms/core-platform/src/main/java/io/fairyproject/container/node/scanner/ContainerNodeLegacyScanner.java
@@ -81,7 +81,7 @@ public class ContainerNodeLegacyScanner {
         InstanceProvider instanceProvider = new MethodInvokeInstanceProvider(null, method);
         Class<?> type = instanceProvider.getType();
 
-        ContainerObj object = this.binder.getBinding(type);
+        ContainerObj object = this.binder.getExactBinding(type);
         if (object == null) {
             object = scanner.createObject(type);
             object.setInstanceProvider(instanceProvider);

--- a/io.fairyproject.platforms/core-platform/src/test/java/io/fairyproject/container/binder/ContainerObjectBinderImplTest.java
+++ b/io.fairyproject.platforms/core-platform/src/test/java/io/fairyproject/container/binder/ContainerObjectBinderImplTest.java
@@ -87,6 +87,19 @@ class ContainerObjectBinderImplTest {
         assertTrue(binder.isBound(interfaceType));
     }
 
+
+    @Test
+    void getExactBinding_ShouldReturnExactTheClassThatRequested() {
+        Class<?> classType = SomeClass.class;
+        Class<?> interfaceType = SomeInterface.class;
+
+        ContainerObj classTypeObj = ContainerObj.create(classType);
+
+        binder.bind(classType, classTypeObj);
+
+        assertNull(binder.getExactBinding(interfaceType));
+    }
+
     @Test
     void recreateBinder_ShouldHaveDifferentContent() {
         Class<?> type = SomeClass.class;


### PR DESCRIPTION
A new method, getExactBinding, has been added to ContainerObjectBinder that retrieves binding for an exact class type, not based on the type hierarchy. The method's implementation has been provided in ContainerObjectBinderImpl. It will directly fetch the binding from the current map of bindings. Accordingly, adjustments have been made in other classes like ContainerNodeConfigurationScanner, ContainerNodeLegacyScanner, and ContainerNodeClassScanner where getBinding is replaced with getExactBinding. A test has also been added to ensure its correct functionality.