### PR TITLE
fix: Fixed OBCClassResolver for future paper (relocation removal.)

### DIFF
--- a/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/nms/BukkitNMSManagerImpl.java
+++ b/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/nms/BukkitNMSManagerImpl.java
@@ -50,19 +50,19 @@ public class BukkitNMSManagerImpl implements BukkitNMSManager {
 
     @PreInitialize
     public void onPreInitialize() {
-        String versionFormat = OBCVersionDecoder.create().decode(serverClass);
-
-        this.nmsClassResolver = setupNmsClassResolver(versionFormat);
-        this.obcClassResolver = setupObcClassResolver(versionFormat);
+        this.nmsClassResolver = setupNmsClassResolver();
+        this.obcClassResolver = setupObcClassResolver();
     }
 
-    private OBCClassResolver setupObcClassResolver(String versionFormat) {
-        return new OBCClassResolver("org.bukkit.craftbukkit." + versionFormat + ".");
+    private OBCClassResolver setupObcClassResolver() {
+        return new OBCClassResolver(serverClass.getPackage().getName());
     }
 
-    private NMSClassResolver setupNmsClassResolver(String versionFormat) {
+    private NMSClassResolver setupNmsClassResolver() {
         MCVersionMapping mapping = this.versionMappingRegistry.findMapping(this.mcServer.getVersion());
         if (mapping.isNmsPrefix()) {
+            String versionFormat = OBCVersionDecoder.create().decode(serverClass);
+
             return new NMSClassResolver("net.minecraft.server." + versionFormat + ".");
         } else {
             return new NMSClassResolver("net.minecraft.");

--- a/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/version/OBCVersionDecoderImpl.java
+++ b/io.fairyproject.platforms/bukkit-platform/src/main/java/io/fairyproject/bukkit/version/OBCVersionDecoderImpl.java
@@ -29,6 +29,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.regex.Pattern;
 
+/**
+ * Implementation of {@link OBCVersionDecoder}
+ *
+ * @deprecated Outdated since Paper 1.20.4 according to <a href="https://forums.papermc.io/threads/important-dev-psa-future-removal-of-cb-package-relocation.1106/">...</a>
+ */
+@Deprecated
 public class OBCVersionDecoderImpl implements OBCVersionDecoder {
 
     @Override


### PR DESCRIPTION
According to the Paper announcement: https://forums.papermc.io/threads/important-dev-psa-future-removal-of-cb-package-relocation.1106/
Changed OBCClassResolver around to solved it.