### PR TITLE
Improve the ModPageGuiSlot to allow for a consumer.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@
 #
 
 # Fairy
-fairy.version = 0.7.1b2-SNAPSHOT
+fairy.version = 0.7.1b3-SNAPSHOT
 gradle-plugin.version = 1.2.0b9
 
 mongojack.version = 4.2.0

--- a/io.fairyproject.modules/platform.bukkit/bukkit-gui/src/main/java/io/fairyproject/bukkit/gui/slot/GuiSlot.java
+++ b/io.fairyproject.modules/platform.bukkit/bukkit-gui/src/main/java/io/fairyproject/bukkit/gui/slot/GuiSlot.java
@@ -77,16 +77,32 @@ public interface GuiSlot {
         return new ModPageGuiSlot(pane, itemStack, 1, null);
     }
 
+    static GuiSlot nextPage(PaginatedPane pane, ItemStack itemStack, @Nullable BiConsumer<Player, ClickType> clickCallback) {
+        return new ModPageGuiSlot(pane, itemStack, 1, clickCallback != null ? event -> clickCallback.accept((Player) event.getWhoClicked(), event.getClick()) : null);
+    }
+
     static GuiSlot previousPage(PaginatedPane pane, ItemStack itemStack) {
         return new ModPageGuiSlot(pane, itemStack, -1, null);
+    }
+
+    static GuiSlot previousPage(PaginatedPane pane, ItemStack itemStack, @Nullable BiConsumer<Player, ClickType> clickCallback) {
+        return new ModPageGuiSlot(pane, itemStack, -1, clickCallback != null ? event -> clickCallback.accept((Player) event.getWhoClicked(), event.getClick()) : null);
     }
 
     static GuiSlot nextPage(PaginatedPane pane) {
         return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aNext Page").build(), 1, null);
     }
 
+    static GuiSlot nextPage(PaginatedPane pane, @Nullable BiConsumer<Player, ClickType> clickCallback) {
+        return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aNext Page").build(), 1, clickCallback != null ? event -> clickCallback.accept((Player) event.getWhoClicked(), event.getClick()) : null);
+    }
+
     static GuiSlot previousPage(PaginatedPane pane) {
         return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aPrevious Page").build(), -1, null);
+    }
+
+    static GuiSlot previousPage(PaginatedPane pane, @Nullable BiConsumer<Player, ClickType> clickCallback) {
+        return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aPrevious Page").build(), -1, clickCallback != null ? event -> clickCallback.accept((Player) event.getWhoClicked(), event.getClick()) : null);
     }
 
     static GuiSlot modPage(PaginatedPane pane, ItemStack itemStack, int mod, @Nullable BiConsumer<Player, ClickType> clickCallback) {

--- a/io.fairyproject.modules/platform.bukkit/bukkit-gui/src/main/java/io/fairyproject/bukkit/gui/slot/GuiSlot.java
+++ b/io.fairyproject.modules/platform.bukkit/bukkit-gui/src/main/java/io/fairyproject/bukkit/gui/slot/GuiSlot.java
@@ -74,23 +74,23 @@ public interface GuiSlot {
     }
 
     static GuiSlot nextPage(PaginatedPane pane, ItemStack itemStack) {
-        return new ModPageGuiSlot(pane, itemStack, 1);
+        return new ModPageGuiSlot(pane, itemStack, 1, null);
     }
 
     static GuiSlot previousPage(PaginatedPane pane, ItemStack itemStack) {
-        return new ModPageGuiSlot(pane, itemStack, -1);
+        return new ModPageGuiSlot(pane, itemStack, -1, null);
     }
 
     static GuiSlot nextPage(PaginatedPane pane) {
-        return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aNext Page").build(), 1);
+        return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aNext Page").build(), 1, null);
     }
 
     static GuiSlot previousPage(PaginatedPane pane) {
-        return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aPrevious Page").build(), -1);
+        return new ModPageGuiSlot(pane, ItemBuilder.of(XMaterial.ARROW).name("&aPrevious Page").build(), -1, null);
     }
 
-    static GuiSlot modPage(PaginatedPane pane, ItemStack itemStack, int mod) {
-        return new ModPageGuiSlot(pane, itemStack, mod);
+    static GuiSlot modPage(PaginatedPane pane, ItemStack itemStack, int mod, @Nullable BiConsumer<Player, ClickType> clickCallback) {
+        return new ModPageGuiSlot(pane, itemStack, mod, clickCallback != null ? event -> clickCallback.accept((Player) event.getWhoClicked(), event.getClick()) : null);
     }
 
     ItemStack getItemStack(@NotNull Player player, @NotNull Gui gui);

--- a/io.fairyproject.modules/platform.bukkit/bukkit-gui/src/main/java/io/fairyproject/bukkit/gui/slot/ModPageGuiSlot.java
+++ b/io.fairyproject.modules/platform.bukkit/bukkit-gui/src/main/java/io/fairyproject/bukkit/gui/slot/ModPageGuiSlot.java
@@ -8,6 +8,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
 
 @RequiredArgsConstructor
 public class ModPageGuiSlot implements GuiSlot {
@@ -15,6 +18,8 @@ public class ModPageGuiSlot implements GuiSlot {
     private final PaginatedPane pane;
     private final ItemStack itemStack;
     private final int mod;
+    @Nullable
+    private final Consumer<InventoryClickEvent> clickCallback;
 
     @Override
     public ItemStack getItemStack(@NotNull Player player, @NotNull Gui gui) {
@@ -37,6 +42,9 @@ public class ModPageGuiSlot implements GuiSlot {
         gui.update(player);
 
         XSound.UI_BUTTON_CLICK.play(player);
+
+        if (clickCallback != null)
+            clickCallback.accept(event);
     }
 
     public void sendCannotPrevious(Player player) {


### PR DESCRIPTION
closes #146

This would allow you to do something like:

```java
navPane.setSlot(8, GuiSlot.modPage(
paginatedPane, 
ItemBuilder.of(XMaterial.ARROW).name("&aNext Page").build(), 
1, 
(clicker, clickType) -> gui.updateTitle(clicker, Component.text("Page: " + paginatedPane.getPage()))));

```