### PR TITLE
fix: text display entity data & teleport packet

### DIFF
--- a/framework/modules/mc/mc-hologram/src/main/java/io/fairyproject/mc/hologram/entity/impl/TextDisplayHologramEntity.java
+++ b/framework/modules/mc/mc-hologram/src/main/java/io/fairyproject/mc/hologram/entity/impl/TextDisplayHologramEntity.java
@@ -24,6 +24,8 @@
 
 package io.fairyproject.mc.hologram.entity.impl;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
 import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
 import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
@@ -99,12 +101,13 @@ public class TextDisplayHologramEntity extends AbstractHologramEntity {
     }
 
     private List<EntityData> createEntityData(MCPlayer mcPlayer) {
+        boolean modern = PacketEvents.getAPI().getServerManager().getVersion().isNewerThanOrEquals(ServerVersion.V_1_20_2);
         List<EntityData> entityDataList = new ArrayList<>();
 
-        entityDataList.add(new EntityData(23, EntityDataTypes.COMPONENT, MCAdventure.asItemString(line.render(mcPlayer), mcPlayer.getLocale()))); // text
-        entityDataList.add(new EntityData(24, EntityDataTypes.INT, 200)); // line width
-        entityDataList.add(new EntityData(25, EntityDataTypes.INT, 0x40000000)); // background color
-        entityDataList.add(new EntityData(26, EntityDataTypes.BYTE, (byte) -1)); // text opacity
+        entityDataList.add(new EntityData(modern ? 23 : 22, EntityDataTypes.COMPONENT, MCAdventure.asItemString(line.render(mcPlayer), mcPlayer.getLocale()))); // text
+        entityDataList.add(new EntityData(modern ? 24 : 23, EntityDataTypes.CAT_VARIANT, 200)); // line width
+        entityDataList.add(new EntityData(modern ? 25 : 24, EntityDataTypes.CAT_VARIANT, 0x40000000)); // background color
+        entityDataList.add(new EntityData(modern ? 26 : 25, EntityDataTypes.CAT_VARIANT, (byte) -1)); // text opacity
         /**
          * bit mask
          * 0x01 = has shadow
@@ -116,7 +119,7 @@ public class TextDisplayHologramEntity extends AbstractHologramEntity {
         boolean isSeeThrough = false;
         boolean useDefaultBackgroundColor = true;
         int alignment = 0;
-        entityDataList.add(new EntityData(27, EntityDataTypes.BYTE, (byte)((hasShadow ? 0x01 : 0) | (isSeeThrough ? 0x02 : 0) | (useDefaultBackgroundColor ? 0x04 : 0) | alignment)));
+        entityDataList.add(new EntityData(modern ? 27 : 26, EntityDataTypes.CAT_VARIANT, (byte)((hasShadow ? 0x01 : 0) | (isSeeThrough ? 0x02 : 0) | (useDefaultBackgroundColor ? 0x04 : 0) | alignment)));
 
         return entityDataList;
     }

--- a/framework/modules/mc/mc-hologram/src/main/java/io/fairyproject/mc/hologram/entity/impl/TextDisplayHologramEntity.java
+++ b/framework/modules/mc/mc-hologram/src/main/java/io/fairyproject/mc/hologram/entity/impl/TextDisplayHologramEntity.java
@@ -105,9 +105,9 @@ public class TextDisplayHologramEntity extends AbstractHologramEntity {
         List<EntityData> entityDataList = new ArrayList<>();
 
         entityDataList.add(new EntityData(modern ? 23 : 22, EntityDataTypes.COMPONENT, MCAdventure.asItemString(line.render(mcPlayer), mcPlayer.getLocale()))); // text
-        entityDataList.add(new EntityData(modern ? 24 : 23, EntityDataTypes.CAT_VARIANT, 200)); // line width
-        entityDataList.add(new EntityData(modern ? 25 : 24, EntityDataTypes.CAT_VARIANT, 0x40000000)); // background color
-        entityDataList.add(new EntityData(modern ? 26 : 25, EntityDataTypes.CAT_VARIANT, (byte) -1)); // text opacity
+        entityDataList.add(new EntityData(modern ? 24 : 23, EntityDataTypes.INT, 200)); // line width
+        entityDataList.add(new EntityData(modern ? 25 : 24, EntityDataTypes.INT, 0x40000000)); // background color
+        entityDataList.add(new EntityData(modern ? 26 : 25, EntityDataTypes.BYTE, (byte) -1)); // text opacity
         /**
          * bit mask
          * 0x01 = has shadow
@@ -119,7 +119,7 @@ public class TextDisplayHologramEntity extends AbstractHologramEntity {
         boolean isSeeThrough = false;
         boolean useDefaultBackgroundColor = true;
         int alignment = 0;
-        entityDataList.add(new EntityData(modern ? 27 : 26, EntityDataTypes.CAT_VARIANT, (byte)((hasShadow ? 0x01 : 0) | (isSeeThrough ? 0x02 : 0) | (useDefaultBackgroundColor ? 0x04 : 0) | alignment)));
+        entityDataList.add(new EntityData(modern ? 27 : 26, EntityDataTypes.BYTE, (byte)((hasShadow ? 0x01 : 0) | (isSeeThrough ? 0x02 : 0) | (useDefaultBackgroundColor ? 0x04 : 0) | alignment)));
 
         return entityDataList;
     }

--- a/framework/modules/mc/mc-hologram/src/main/java/io/fairyproject/mc/hologram/entity/impl/TextDisplayHologramEntity.java
+++ b/framework/modules/mc/mc-hologram/src/main/java/io/fairyproject/mc/hologram/entity/impl/TextDisplayHologramEntity.java
@@ -72,8 +72,8 @@ public class TextDisplayHologramEntity extends AbstractHologramEntity {
         WrapperPlayServerEntityTeleport packet = new WrapperPlayServerEntityTeleport(
                 this.entityId,
                 this.packetPosition(),
-                this.hologram.getPosition().getPitch(),
                 this.hologram.getPosition().getYaw(),
+                this.hologram.getPosition().getPitch(),
                 false
         );
         WrapperPlayServerEntityMetadata metadataPacket = new WrapperPlayServerEntityMetadata(
@@ -101,10 +101,10 @@ public class TextDisplayHologramEntity extends AbstractHologramEntity {
     private List<EntityData> createEntityData(MCPlayer mcPlayer) {
         List<EntityData> entityDataList = new ArrayList<>();
 
-        entityDataList.add(new EntityData(22, EntityDataTypes.COMPONENT, MCAdventure.asItemString(line.render(mcPlayer), mcPlayer.getLocale()))); // text
-        entityDataList.add(new EntityData(23, EntityDataTypes.CAT_VARIANT, 200)); // line width
-        entityDataList.add(new EntityData(24, EntityDataTypes.CAT_VARIANT, 0x40000000)); // background color
-        entityDataList.add(new EntityData(25, EntityDataTypes.CAT_VARIANT, -1)); // text opacity
+        entityDataList.add(new EntityData(23, EntityDataTypes.COMPONENT, MCAdventure.asItemString(line.render(mcPlayer), mcPlayer.getLocale()))); // text
+        entityDataList.add(new EntityData(24, EntityDataTypes.INT, 200)); // line width
+        entityDataList.add(new EntityData(25, EntityDataTypes.INT, 0x40000000)); // background color
+        entityDataList.add(new EntityData(26, EntityDataTypes.BYTE, (byte) -1)); // text opacity
         /**
          * bit mask
          * 0x01 = has shadow
@@ -116,7 +116,7 @@ public class TextDisplayHologramEntity extends AbstractHologramEntity {
         boolean isSeeThrough = false;
         boolean useDefaultBackgroundColor = true;
         int alignment = 0;
-        entityDataList.add(new EntityData(26, EntityDataTypes.CAT_VARIANT, (hasShadow ? 0x01 : 0) | (isSeeThrough ? 0x02 : 0) | (useDefaultBackgroundColor ? 0x04 : 0) | alignment));
+        entityDataList.add(new EntityData(27, EntityDataTypes.BYTE, (byte)((hasShadow ? 0x01 : 0) | (isSeeThrough ? 0x02 : 0) | (useDefaultBackgroundColor ? 0x04 : 0) | alignment)));
 
         return entityDataList;
     }


### PR DESCRIPTION
The latest version of Fairy is using incorrect index of text display entity data, causing spawning a hologram will kick the player out from the sever. 
![image](https://github.com/user-attachments/assets/eafc79fa-09b0-46e1-b1fa-57a41198edcd)

Also, the teleport packet in the text display hologram update function is using incorrect pitch and yaw, causing hologram looks into the wrong direction.  

This PR should fix both errors.