### PR TITLE
feat(gradle): enhance repository configuration flexibility (v0.7)

### DIFF
--- a/build-logic/src/main/kotlin/io.fairyproject.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/io.fairyproject.publish.gradle.kts
@@ -63,14 +63,15 @@ afterEvaluate {
         }
 
         repositories {
-            maven {
-                name = "Production"
-                url = uri("https://repo.imanity.dev/imanity-libraries/")
-                credentials {
-                    username = findProperty("imanityLibrariesUsername").toString()
-                    password = findProperty("imanityLibrariesPassword").toString()
-                }
-            }
+            mavenLocal()
+//            maven {
+//                name = "Production"
+//                url = uri("https://repo.imanity.dev/imanity-libraries/")
+//                credentials {
+//                    username = findProperty("imanityLibrariesUsername").toString()
+//                    password = findProperty("imanityLibrariesPassword").toString()
+//                }
+//            }
         }
     }
 }

--- a/build-logic/src/main/kotlin/io.fairyproject.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/io.fairyproject.publish.gradle.kts
@@ -63,15 +63,14 @@ afterEvaluate {
         }
 
         repositories {
-            mavenLocal()
-//            maven {
-//                name = "Production"
-//                url = uri("https://repo.imanity.dev/imanity-libraries/")
-//                credentials {
-//                    username = findProperty("imanityLibrariesUsername").toString()
-//                    password = findProperty("imanityLibrariesPassword").toString()
-//                }
-//            }
+            maven {
+                name = "Production"
+                url = uri("https://repo.imanity.dev/imanity-libraries/")
+                credentials {
+                    username = findProperty("imanityLibrariesUsername").toString()
+                    password = findProperty("imanityLibrariesPassword").toString()
+                }
+            }
         }
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/fairyproject/gradle/FairyGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/fairyproject/gradle/FairyGradlePlugin.kt
@@ -23,10 +23,14 @@ import org.gradle.api.tasks.SourceSetContainer
 class FairyGradlePlugin : Plugin<Project> {
 
     private lateinit var sourceSets: SourceSetContainer
+    private lateinit var extension: FairyExtension
 
     override fun apply(project: Project) {
-        project.extensions.create("fairy", FairyExtension::class.java)
-        this.configureRepositories(project)
+        extension = project.extensions.create("fairy", FairyExtension::class.java)
+        
+        project.afterEvaluate {
+            configureRepositories(project)
+        }
 
         project.plugins.apply(JavaBasePlugin::class.java)
         project.plugins.apply(FairyResourcePlugin::class.java)
@@ -51,18 +55,28 @@ class FairyGradlePlugin : Plugin<Project> {
     }
 
     private fun configureRepositories(project: Project) {
-        project.repositories.maven { it.setUrl(UrlConstants.repositoryUrl) }
-        project.repositories.maven {
-            it.setUrl(UrlConstants.codeMcReleaseRepositoryUrl)
-            it.content {
-                it.includeGroup("com.github.retrooper")
-            }
+        if (extension.overrideRepositories) {
+            project.repositories.clear()
         }
-        project.repositories.maven {
-            it.setUrl(UrlConstants.codeMcSnapshotRepositoryUrl)
-            it.content {
-                it.includeGroup("com.github.retrooper")
-            }
+
+        if (extension.addDefaultRepositories) {
+            project.repositories.addFirst(project.repositories.maven { 
+                it.setUrl(UrlConstants.repositoryUrl)
+            })
+
+            project.repositories.addFirst(project.repositories.maven {
+                it.setUrl(UrlConstants.codeMcReleaseRepositoryUrl)
+                it.content {
+                    it.includeGroup("com.github.retrooper")
+                }
+            })
+
+            project.repositories.addFirst(project.repositories.maven {
+                it.setUrl(UrlConstants.codeMcSnapshotRepositoryUrl)
+                it.content {
+                    it.includeGroup("com.github.retrooper")
+                }
+            })
         }
     }
 

--- a/gradle-plugin/src/main/kotlin/io/fairyproject/gradle/extension/FairyExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/fairyproject/gradle/extension/FairyExtension.kt
@@ -19,6 +19,18 @@ open class FairyExtension(objectFactory: ObjectFactory) {
     private val properties = mutableMapOf<PlatformType, Properties>()
 
     /**
+     * Whether to override the project's existing repositories
+     * Default is false, meaning keep existing configuration
+     */
+    var overrideRepositories: Boolean = false
+
+    /**
+     * Whether to add default Fairy repositories
+     * Default is true
+     */
+    var addDefaultRepositories: Boolean = true
+
+    /**
      * Get properties for bukkit platform
      */
     fun bukkitProperties(): BukkitProperties = this.properties.computeIfAbsent(PlatformType.BUKKIT) { BukkitProperties() } as BukkitProperties


### PR DESCRIPTION
## 問題描述
目前 Fairy Gradle Plugin 在應用時會強制覆蓋專案的 repository 配置，這可能會導致：
1. 使用者原有的 repository 配置被清除
2. 依賴解析失敗
3. 無法使用自定義的 repository

情境描述：
1. 專案使用 settings.gradle.kts 的 dependencyResolutionManagement 來管理所有依賴項目的倉庫 (build.gradle.kts 就不定義 repository 了)
2. 在正常情況下，所有依賴都可以正確解析
3. 但當我在 build.gradle.kts 中引入 `id("io.fairyproject")` 插件後，所有依賴突然都無法被找到
4. 這個插件似乎改變了依賴解析的行為，但我不確定它內部做了什麼

## 改動內容

### 1. 新增配置選項
在 `FairyExtension` 中添加兩個配置項：
```kotlin
var overrideRepositories: Boolean = false    // 是否覆蓋現有 repositories
var addDefaultRepositories: Boolean = true   // 是否添加預設 Fairy repositories
```

### 2. 修改 Repository 配置邏輯
- 將 repository 配置移至 `project.afterEvaluate` 階段
- 根據配置決定是否清除現有 repositories
- 使用 `addFirst` 來確保 Fairy repositories 的優先級

## 影響評估

### 對現有開發者的影響
- 向後相容：預設行為保持不變（`addDefaultRepositories = true`）
- 不會影響現有的建構腳本
- 不需要修改現有的程式碼

### 對新開發者的好處
現在可以更靈活地配置 repositories：

```kotlin
fairy {
    // 選擇是否要保留現有的 repositories
    overrideRepositories = false
    
    // 選擇是否要使用 Fairy 預設的 repositories
    addDefaultRepositories = true
}

// 可以添加自定義的 repositories
repositories {
    mavenCentral()
    maven {
        url = uri("https://your-custom-repo.com")
    }
}
```

## 使用說明

### 基本使用（保持原有行為）
不需要任何額外配置，插件會：
- 保留現有的 repositories
- 添加 Fairy 預設的 repositories

### 完全控制
如果需要完全控制 repositories：
```kotlin
fairy {
    overrideRepositories = true  // 清除現有配置
    addDefaultRepositories = false  // 不添加預設配置
}

repositories {
    // 完全自定義的 repository 配置
}
```

### 混合使用
```kotlin
fairy {
    overrideRepositories = false  // 保留現有配置
    addDefaultRepositories = true  // 使用預設配置
}

repositories {
    // 添加額外的 repositories
}
```

## 測試建議
1. 確認預設配置的向後相容性
2. 驗證自定義 repository 配置是否生效
3. 檢查依賴解析順序是否符合預期
4. 測試不同配置組合的情況

## 相關文件
- FairyGradlePlugin.kt
- FairyExtension.kt
