### PR TITLE
feat: Add MC 26.2 Support

### DIFF
--- a/framework/platforms/bukkit-platform/build.gradle.kts
+++ b/framework/platforms/bukkit-platform/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     api(project(":mc-platform"))
     api("net.kyori:adventure-platform-bukkit:4.4.1")
     api("net.kyori:adventure-text-serializer-bungeecord:4.4.1")
-    api("com.github.retrooper:packetevents-spigot:2.12.2") {
+    api("com.github.retrooper:packetevents-spigot:2.13.0") {
         exclude(group = "net.kyori")
     }
     compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT") {

--- a/framework/platforms/mc-platform/build.gradle.kts
+++ b/framework/platforms/mc-platform/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     api("net.kyori:adventure-text-serializer-gson-legacy-impl:4.25.0")
     api("net.kyori:adventure-text-serializer-plain:4.25.0")
 
-    api("com.github.retrooper:packetevents-api:2.12.2") {
+    api("com.github.retrooper:packetevents-api:2.13.0") {
         exclude(group = "net.kyori")
     }
 

--- a/framework/platforms/mc-platform/src/main/java/io/fairyproject/mc/MCAdventure.java
+++ b/framework/platforms/mc-platform/src/main/java/io/fairyproject/mc/MCAdventure.java
@@ -8,7 +8,7 @@ import lombok.Data;
 import lombok.experimental.UtilityClass;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.kyori.adventure.translation.GlobalTranslator;
 

--- a/framework/platforms/mc-platform/src/main/java/io/fairyproject/mc/version/MCVersionMappingRegistry.java
+++ b/framework/platforms/mc-platform/src/main/java/io/fairyproject/mc/version/MCVersionMappingRegistry.java
@@ -47,7 +47,7 @@ import java.util.TreeSet;
 public class MCVersionMappingRegistry {
 
     // Hardcoded latest version to validate cache
-    private static final MCVersion LATEST_VERSION = MCVersion.of(26, 1, 0);
+    private static final MCVersion LATEST_VERSION = MCVersion.of(26, 2, 0);
 
     private final Gson gson = new Gson();
     @Getter
@@ -143,8 +143,10 @@ public class MCVersionMappingRegistry {
 
         boolean hexColor = major >= 1 && minor >= 16;
         boolean nmsPrefix = major < 1 || minor < 17;
-        if (major > 1)
+        if (major > 1) {
+            hexColor = true;
             nmsPrefix = false;
+        }
 
         this.register(new MCVersionMapping(major, minor, patch, nmsPrefix, hexColor, protocolVersion));
     }


### PR DESCRIPTION
- Packetevents 2.12.2 -> 2.13.0 (26.2 support is there).
- LATEST_VERSION 26.1 -> 26.2.
- hexColor was gated on minor >= 16 so 26.x came out non-hex, added a major > 1 guard like nmsPrefix already has.
- Paper 26.2 moved to adventure 5.2.0 which drops the gson LegacyHoverEventSerializer, so MCAdventure uses the json one now. its in 4.25.0 too so the older versions are unaffected.